### PR TITLE
🐛 fix: mode별 속도 제한 단위 보정 및 값 상향 (m/s 기준)

### DIFF
--- a/tasks/transportShared.js
+++ b/tasks/transportShared.js
@@ -21,8 +21,8 @@ export const STORAGE = {
   STOPPING: "@transport/stopping",
 };
 
-export const SPEED_LIMITS = { WALK: 3.5, BIKE: 12, TRANSIT: Infinity };
-export const ARRIVAL_RADIUS_M = 50; // 도착 판정 반경
+export const SPEED_LIMITS = { WALK: 7, BIKE: 14, TRANSIT: Infinity };
+export const ARRIVAL_RADIUS_M = 40; // 도착 판정 반경
 export const ACCURACY_MAX_M = 35; // 정확도 상한(근처에선 조금 더 허용)
 export const IGNORE_MIN_MOVE_M = 1; // 미세 이동 무시
 export const JUMP_THRESH_M = 120; // 갑툭튀 무시 임계값

--- a/tasks/transportShared.js
+++ b/tasks/transportShared.js
@@ -22,7 +22,7 @@ export const STORAGE = {
 };
 
 export const SPEED_LIMITS = { WALK: 7, BIKE: 14, TRANSIT: Infinity };
-export const ARRIVAL_RADIUS_M = 40; // 도착 판정 반경
+export const ARRIVAL_RADIUS_M = 35; // 도착 판정 반경
 export const ACCURACY_MAX_M = 35; // 정확도 상한(근처에선 조금 더 허용)
 export const IGNORE_MIN_MOVE_M = 1; // 미세 이동 무시
 export const JUMP_THRESH_M = 120; // 갑툭튀 무시 임계값

--- a/tasks/transportTrackingTask.js
+++ b/tasks/transportTrackingTask.js
@@ -45,7 +45,8 @@ if (!global.__TRANSPORT_TASK_DEFINED__) {
       if (!id || isActive !== "1") {
         dlog("BG", { stop: "not_active_or_no_id" });
         try {
-          const started = await Location.hasStartedLocationUpdatesAsync(TASK_NAME);
+          const started =
+            await Location.hasStartedLocationUpdatesAsync(TASK_NAME);
           if (started) await Location.stopLocationUpdatesAsync(TASK_NAME);
         } catch {}
         return;
@@ -60,11 +61,30 @@ if (!global.__TRANSPORT_TASK_DEFINED__) {
         return;
       }
 
-      const d = calculateDistance(prev.latitude, prev.longitude, latitude, longitude);
+      // 출발 후 2초 이내면 거리 무시
+      const startAt = await AsyncStorage.getItem(STORAGE.START);
+      if (startAt && now - Number(startAt) < 2000) {
+        dlog("BG", {
+          ignore: "startup_grace_period",
+          elapsed: now - Number(startAt),
+        });
+        return;
+      }
+
+      const d = calculateDistance(
+        prev.latitude,
+        prev.longitude,
+        latitude,
+        longitude
+      );
       const dt = (now - (prev.timestamp || now)) / 1000;
       const ignore = shouldIgnoreMove(d, dt);
       if (ignore.ignore) {
-        dlog("BG", { ignore: ignore.reason, d: Math.round(d), dt: Math.round(dt * 10) / 10 });
+        dlog("BG", {
+          ignore: ignore.reason,
+          d: Math.round(d),
+          dt: Math.round(dt * 10) / 10,
+        });
         return;
       }
 
@@ -79,7 +99,12 @@ if (!global.__TRANSPORT_TASK_DEFINED__) {
         const instSpeed = d / dt;
         const speed = checkSpeed(instSpeed, mode);
         if (speed.over) {
-          dlog("BG", { speedViolation: true, mode, speed: Math.round(speed.speed * 100) / 100, limit: speed.limit });
+          dlog("BG", {
+            speedViolation: true,
+            mode,
+            speed: Math.round(speed.speed * 100) / 100,
+            limit: speed.limit,
+          });
           await AsyncStorage.multiSet([
             [STORAGE.STOPPED, "1"],
             [STORAGE.STOP_KIND, "fail"],
@@ -87,7 +112,8 @@ if (!global.__TRANSPORT_TASK_DEFINED__) {
             [STORAGE.ACTIVE, "0"],
           ]);
           try {
-            const started = await Location.hasStartedLocationUpdatesAsync(TASK_NAME);
+            const started =
+              await Location.hasStartedLocationUpdatesAsync(TASK_NAME);
             if (started) await Location.stopLocationUpdatesAsync(TASK_NAME);
           } catch {}
           return;
@@ -106,7 +132,8 @@ if (!global.__TRANSPORT_TASK_DEFINED__) {
         dlog("BG", { arrival: true, stopped: !!ar.stopped });
         // BG 업데이트 중지
         try {
-          const started = await Location.hasStartedLocationUpdatesAsync(TASK_NAME);
+          const started =
+            await Location.hasStartedLocationUpdatesAsync(TASK_NAME);
           if (started) await Location.stopLocationUpdatesAsync(TASK_NAME);
         } catch {}
       }


### PR DESCRIPTION
## ✅ 작업 내용
- mode별 속도 제한 단위(m/s) 보정 및 현실적인 값으로 상향
- 출발 후 2초간 이동 거리 무시하여 GPS 드리프트 방지
- 도착 판정 반경 50m → 35m 축소로 더 정밀한 판정

## 🔗 관련 이슈
Closes #196 
